### PR TITLE
Make @words accessible from the outside

### DIFF
--- a/lib/Acme/LastWords.pm
+++ b/lib/Acme/LastWords.pm
@@ -6,7 +6,7 @@ package Acme::LastWords;
 use strict;
 use warnings;
 
-my @words = (
+our @words = (
     "Dictionary.", # Joseph Wright
     "Happy.", # Raphael
     "Mozart!", # Gustav Mahler


### PR DESCRIPTION
That way, once you have enough citations, we can create `Acme::MetaSyntactic::last_words` and populate it with `@words`.
